### PR TITLE
Improve list commands

### DIFF
--- a/api/companies.go
+++ b/api/companies.go
@@ -38,7 +38,8 @@ func (cs *CompaniesList) apiURL() string {
 	return "v1/companies"
 }
 
-func (cs *CompaniesList) slug() string {
+// Slug is used to represent the model in cli
+func (cs *CompaniesList) Slug() string {
 	return "companies"
 }
 

--- a/api/contracts.go
+++ b/api/contracts.go
@@ -38,7 +38,8 @@ func (cs *ContractsList) apiURL() string {
 	return "v1/my_contracts"
 }
 
-func (cs *ContractsList) slug() string {
+// Slug is used to represent the model in cli
+func (cs *ContractsList) Slug() string {
 	return "contracts"
 }
 

--- a/api/models.go
+++ b/api/models.go
@@ -5,26 +5,17 @@ package api
 var Models = &models{}
 
 type models struct {
-	models []modelList
+	Models []ModelList
 }
 
-func (c *models) register(m modelList) {
-	c.models = append(c.models, m)
-}
-
-// List return the list of models
-func (c *models) List() []string {
-	var r []string
-	for _, m := range c.models {
-		r = append(r, m.slug())
-	}
-	return r
+func (c *models) register(m ModelList) {
+	c.Models = append(c.Models, m)
 }
 
 // List return the models that match the slug
-func (c *models) GetBySlug(slug string) modelList {
-	for _, m := range c.models {
-		if m.slug() == slug {
+func (c *models) GetBySlug(slug string) ModelList {
+	for _, m := range c.Models {
+		if m.Slug() == slug {
 			return m
 		}
 	}

--- a/api/performances.go
+++ b/api/performances.go
@@ -108,7 +108,8 @@ func (ps *PerformancesList) isEmpty() bool {
 	return len(ps.Performances) == 0
 }
 
-func (ps *PerformancesList) slug() string {
+// Slug is used to represent the model in cli
+func (ps *PerformancesList) Slug() string {
 	return "performances"
 }
 

--- a/api/performances_rate.go
+++ b/api/performances_rate.go
@@ -38,7 +38,8 @@ func (pr *PerformanceRatesList) apiURL() string {
 	return "v1/performance_types"
 }
 
-func (pr *PerformanceRatesList) slug() string {
+// Slug is used to represent the model in cli
+func (pr *PerformanceRatesList) Slug() string {
 	return "rates"
 }
 

--- a/api/timesheets.go
+++ b/api/timesheets.go
@@ -64,7 +64,8 @@ func (ts *TimesheetsList) apiURL() string {
 	return "v1/my_timesheets"
 }
 
-func (ts *TimesheetsList) slug() string {
+// Slug is used to represent the model in cli
+func (ts *TimesheetsList) Slug() string {
 	return "timesheets"
 }
 

--- a/api/users.go
+++ b/api/users.go
@@ -43,7 +43,8 @@ type UsersList struct {
 	Users []User `json:"results"`
 }
 
-func (users *UsersList) slug() string {
+// Slug is used to represent the model in cli
+func (users *UsersList) Slug() string {
 	return "users"
 }
 

--- a/tests/list_performances_test.go
+++ b/tests/list_performances_test.go
@@ -99,11 +99,11 @@ func TestListPerformanceWithWrongColumns(t *testing.T) {
 		ErrLines:      17,
 		ErrText: `Error: invalid columns: nonexisting, extra
 Usage:
-  12to8 list MODEL [args...] [flags]
+  12to8 list performances [flags]
 
 Flags:
   -C, --columns string   comma-separated columns to be displayed
-  -h, --help             help for list
+  -h, --help             help for performances
   -P, --porcelain        porcelain (usable in scripts) output
 
 Global Flags:


### PR DESCRIPTION
I am happy now.

We have:

```
$ 12to8 list
list timesheets, performances, leaves...

Usage:
  12to8 list [command]

Available Commands:
  companies    list the companies
  contracts    list the contracts
  performances list the performances
  rates        list the rates
  timesheets   list the timesheets
  users        list the users
```

Better explanation than `12to8 list [models]`