### PR TITLE
Remove default Cobra output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,13 +30,8 @@ var force bool
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "12to8",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "A client for 925r",
+	Long:  "12to8 is a commandline application for the 925r, a free and open source time and leave tracking application.",
 	BashCompletionFunction: bashCompletionFunc,
 }
 


### PR DESCRIPTION
Remove default Cobra output and replace it with something more descriptive

Signed-off-by: Christophe Vanlancker <carroarmato0@inuits.eu>